### PR TITLE
Improve PHPUnit fixtures

### DIFF
--- a/tests/Crawler/RobotsAwareCrawlerTest.php
+++ b/tests/Crawler/RobotsAwareCrawlerTest.php
@@ -30,7 +30,7 @@ class RobotsAwareCrawlerTest extends TestCase
     private $parser;
     private $inner;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->crawl = new RobotsAwareCrawler(
             $this->parser = $this->createMock(Parser::class),

--- a/tests/Publisher/AlternatesAwarePublisherTest.php
+++ b/tests/Publisher/AlternatesAwarePublisherTest.php
@@ -35,7 +35,7 @@ class AlternatesAwarePublisherTest extends TestCase
     private $inner;
     private $producer;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->publisher = new AlternatesAwarePublisher(
             $this->inner = $this->createMock(Publisher::class),

--- a/tests/Publisher/CanonicalAwarePublisherTest.php
+++ b/tests/Publisher/CanonicalAwarePublisherTest.php
@@ -27,7 +27,7 @@ class CanonicalAwarePublisherTest extends TestCase
     private $inner;
     private $producer;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->publisher = new CanonicalAwarePublisher(
             $this->inner = $this->createMock(Publisher::class),

--- a/tests/Publisher/ImagesAwarePublisherTest.php
+++ b/tests/Publisher/ImagesAwarePublisherTest.php
@@ -30,7 +30,7 @@ class ImagesAwarePublisherTest extends TestCase
     private $inner;
     private $producer;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->publisher = new ImagesAwarePublisher(
             $this->inner = $this->createMock(Publisher::class),

--- a/tests/Publisher/LinksAwarePublisherTest.php
+++ b/tests/Publisher/LinksAwarePublisherTest.php
@@ -33,7 +33,7 @@ class LinksAwarePublisherTest extends TestCase
     private $inner;
     private $producer;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->publisher = new LinksAwarePublisher(
             $this->inner = $this->createMock(Publisher::class),

--- a/tests/Publisher/PublisherTest.php
+++ b/tests/Publisher/PublisherTest.php
@@ -40,7 +40,7 @@ class PublisherTest extends TestCase
     private $publisher;
     private $client;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->publisher = new Publisher(
             $this->client = $this->createMock(Client::class),

--- a/tests/RobotsTxt/CacheParserTest.php
+++ b/tests/RobotsTxt/CacheParserTest.php
@@ -24,7 +24,7 @@ class CacheParserTest extends TestCase
     private $inner;
     private $filesystem;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->parser = new CacheParser(
             $this->inner = $this->createMock(Parser::class),

--- a/tests/Translator/Property/CharsetTranslatorTest.php
+++ b/tests/Translator/Property/CharsetTranslatorTest.php
@@ -30,7 +30,7 @@ class CharsetTranslatorTest extends TestCase
     private $translator;
     private $property;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->translator = new CharsetTranslator;
         $this->property = new Property(

--- a/tests/Translator/Property/DelegationTranslatorTest.php
+++ b/tests/Translator/Property/DelegationTranslatorTest.php
@@ -33,7 +33,7 @@ class DelegationTranslatorTest extends TestCase
     private $host;
     private $foo;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->translator = new DelegationTranslator(
             Map::of('string', PropertyTranslator::class)

--- a/tests/Translator/Property/HostTranslatorTest.php
+++ b/tests/Translator/Property/HostTranslatorTest.php
@@ -30,7 +30,7 @@ class HostTranslatorTest extends TestCase
     private $translator;
     private $property;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->translator = new HostTranslator;
         $this->property = new Property(

--- a/tests/Translator/Property/HtmlPage/AnchorsTranslatorTest.php
+++ b/tests/Translator/Property/HtmlPage/AnchorsTranslatorTest.php
@@ -30,7 +30,7 @@ class AnchorsTranslatorTest extends TestCase
     private $translator;
     private $property;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->translator = new AnchorsTranslator;
         $this->property = new Property(

--- a/tests/Translator/Property/HtmlPage/AndroidAppLinkTranslatorTest.php
+++ b/tests/Translator/Property/HtmlPage/AndroidAppLinkTranslatorTest.php
@@ -30,7 +30,7 @@ class AndroidAppLinkTranslatorTest extends TestCase
     private $translator;
     private $property;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->translator = new AndroidAppLinkTranslator;
         $this->property = new Property(

--- a/tests/Translator/Property/HtmlPage/AuthorTranslatorTest.php
+++ b/tests/Translator/Property/HtmlPage/AuthorTranslatorTest.php
@@ -30,7 +30,7 @@ class AuthorTranslatorTest extends TestCase
     private $translator;
     private $property;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->translator = new AuthorTranslator;
         $this->property = new Property(

--- a/tests/Translator/Property/HtmlPage/CitationsTranslatorTest.php
+++ b/tests/Translator/Property/HtmlPage/CitationsTranslatorTest.php
@@ -30,7 +30,7 @@ class CitationsTranslatorTest extends TestCase
     private $translator;
     private $property;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->translator = new CitationsTranslator;
         $this->property = new Property(

--- a/tests/Translator/Property/HtmlPage/DescriptionTranslatorTest.php
+++ b/tests/Translator/Property/HtmlPage/DescriptionTranslatorTest.php
@@ -30,7 +30,7 @@ class DescriptionTranslatorTest extends TestCase
     private $translator;
     private $property;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->translator = new DescriptionTranslator;
         $this->property = new Property(

--- a/tests/Translator/Property/HtmlPage/IosAppLinkTranslatorTest.php
+++ b/tests/Translator/Property/HtmlPage/IosAppLinkTranslatorTest.php
@@ -30,7 +30,7 @@ class IosAppLinkTranslatorTest extends TestCase
     private $translator;
     private $property;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->translator = new IosAppLinkTranslator;
         $this->property = new Property(

--- a/tests/Translator/Property/HtmlPage/IsJournalTranslatorTest.php
+++ b/tests/Translator/Property/HtmlPage/IsJournalTranslatorTest.php
@@ -30,7 +30,7 @@ class IsJournalTranslatorTest extends TestCase
     private $translator;
     private $property;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->translator = new IsJournalTranslator;
         $this->property = new Property(

--- a/tests/Translator/Property/HtmlPage/MainContentTranslatorTest.php
+++ b/tests/Translator/Property/HtmlPage/MainContentTranslatorTest.php
@@ -30,7 +30,7 @@ class MainContentTranslatorTest extends TestCase
     private $translator;
     private $property;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->translator = new MainContentTranslator;
         $this->property = new Property(

--- a/tests/Translator/Property/HtmlPage/PreviewTranslatorTest.php
+++ b/tests/Translator/Property/HtmlPage/PreviewTranslatorTest.php
@@ -30,7 +30,7 @@ class PreviewTranslatorTest extends TestCase
     private $translator;
     private $property;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->translator = new PreviewTranslator;
         $this->property = new Property(

--- a/tests/Translator/Property/HtmlPage/ThemeColourTranslatorTest.php
+++ b/tests/Translator/Property/HtmlPage/ThemeColourTranslatorTest.php
@@ -31,7 +31,7 @@ class ThemeColourTranslatorTest extends TestCase
     private $translator;
     private $property;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->translator = new ThemeColourTranslator;
         $this->property = new Property(

--- a/tests/Translator/Property/HtmlPage/TitleTranslatorTest.php
+++ b/tests/Translator/Property/HtmlPage/TitleTranslatorTest.php
@@ -30,7 +30,7 @@ class TitleTranslatorTest extends TestCase
     private $translator;
     private $property;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->translator = new TitleTranslator;
         $this->property = new Property(

--- a/tests/Translator/Property/Image/DimensionTranslatorTest.php
+++ b/tests/Translator/Property/Image/DimensionTranslatorTest.php
@@ -31,7 +31,7 @@ class DimensionTranslatorTest extends TestCase
     private $translator;
     private $property;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->translator = new DimensionTranslator;
         $this->property = new Property(

--- a/tests/Translator/Property/Image/WeightTranslatorTest.php
+++ b/tests/Translator/Property/Image/WeightTranslatorTest.php
@@ -33,7 +33,7 @@ class WeightTranslatorTest extends TestCase
     private $translator;
     private $property;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->translator = new WeightTranslator;
         $this->property = new Property(

--- a/tests/Translator/Property/LanguagesTranslatorTest.php
+++ b/tests/Translator/Property/LanguagesTranslatorTest.php
@@ -30,7 +30,7 @@ class LanguagesTranslatorTest extends TestCase
     private $translator;
     private $property;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->translator = new LanguagesTranslator;
         $this->property = new Property(

--- a/tests/Translator/Property/PathTranslatorTest.php
+++ b/tests/Translator/Property/PathTranslatorTest.php
@@ -30,7 +30,7 @@ class PathTranslatorTest extends TestCase
     private $translator;
     private $property;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->translator = new PathTranslator;
         $this->property = new Property(

--- a/tests/Translator/Property/QueryTranslatorTest.php
+++ b/tests/Translator/Property/QueryTranslatorTest.php
@@ -30,7 +30,7 @@ class QueryTranslatorTest extends TestCase
     private $translator;
     private $property;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->translator = new QueryTranslator;
         $this->property = new Property(


### PR DESCRIPTION
# Changed log

- According to the official [PHPUnit doc](https://phpunit.readthedocs.io/en/8.5/fixtures.html#more-setup-than-teardown), it should be `protected function setUp(): void`.